### PR TITLE
Reuse book table on genre details page

### DIFF
--- a/src/components/BookTable.tsx
+++ b/src/components/BookTable.tsx
@@ -6,9 +6,10 @@ import { BookWithGenres } from "@/lib/database-factory";
 
 interface BookTableProps {
   books: BookWithGenres[];
+  baseUrl?: string;
 }
 
-export default function BookTable({ books }: BookTableProps) {
+export default function BookTable({ books, baseUrl = '/books' }: BookTableProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -32,7 +33,7 @@ export default function BookTable({ books }: BookTableProps) {
     params.set('sortOrder', newSortOrder);
     params.set('page', '1'); // Reset to first page when sorting changes
     
-    router.push(`/books?${params.toString()}`);
+    router.push(`${baseUrl}?${params.toString()}`);
   };
 
   const getSortIcon = (field: string) => {

--- a/src/components/GenreView.tsx
+++ b/src/components/GenreView.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { Genre } from '@/lib/database-factory';
+import { Genre, BookWithGenres } from '@/lib/database-factory';
+import BookTable from '@/components/BookTable';
 
 interface GenreViewProps {
   genreId: string;
@@ -14,7 +15,7 @@ export default function GenreView({ genreId }: GenreViewProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
   const [isDeleting, setIsDeleting] = useState(false);
-  const [books, setBooks] = useState<Array<{id: string; title: string; author: string}>>([]);
+  const [books, setBooks] = useState<BookWithGenres[]>([]);
   const router = useRouter();
 
   const fetchGenre = useCallback(async () => {
@@ -168,27 +169,7 @@ export default function GenreView({ genreId }: GenreViewProps) {
             {books.length === 0 ? (
               <p className="text-gray-400 italic">No books found for this genre.</p>
             ) : (
-              <ul className="divide-y divide-gray-200">
-                {books.map((book) => (
-                  <li key={book.id} className="py-2">
-                    <a href={`/books/${book.id}`} className="text-blue-700 hover:underline font-medium">
-                      {book.title}
-                    </a>
-                    <span className="ml-2 text-gray-600 text-sm">
-                      by <span 
-                        className="cursor-pointer hover:text-blue-600 transition-colors"
-                        onClick={() => {
-                          const params = new URLSearchParams();
-                          params.set('search', book.author);
-                          window.location.href = `/books?${params.toString()}`;
-                        }}
-                      >
-                        {book.author}
-                      </span>
-                    </span>
-                  </li>
-                ))}
-              </ul>
+              <BookTable books={books} baseUrl={`/genres/${genreId}`} />
             )}
           </div>
 

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -366,16 +366,6 @@ function getGenresForBook(bookId: string): Genre[] {
   return stmt.all(bookId) as Genre[];
 }
 
-function getBooksByGenre(genreId: string): Book[] {
-  const stmt = db.prepare(`
-    SELECT b.* FROM books b
-    INNER JOIN book_genres bg ON b.id = bg.book_id
-    WHERE bg.genre_id = ?
-    ORDER BY b.title
-  `);
-  return stmt.all(genreId) as Book[];
-}
-
 // User operations
 export const userOperations = {
   // Create a new user
@@ -1004,19 +994,20 @@ export const bookOperations = {
   },
 
   // Get books by genre
-  getBooksByGenre: (genreId: string): Book[] => {
+  getBooksByGenre: (genreId: string): BookWithGenres[] => {
     return getBooksForGenre(genreId);
   }
 };
 
-export function getBooksForGenre(genreId: string) {
+export function getBooksForGenre(genreId: string): BookWithGenres[] {
   const stmt = db.prepare(`
     SELECT b.* FROM books b
     INNER JOIN book_genres bg ON b.id = bg.book_id
     WHERE bg.genre_id = ?
     ORDER BY b.title
   `);
-  return stmt.all(genreId) as Book[];
+  const books = stmt.all(genreId) as Book[];
+  return books.map(book => ({ ...book, genres: getGenresForBook(book.id) }));
 }
 
 // Genre CRUD operations

--- a/todos.md
+++ b/todos.md
@@ -3,6 +3,6 @@
 3. ✅ use icons for view/edit instead of spelled out words (by default) 
 4. ✅ Make the reading list page more like a list than cards.
 5. ✅ Add support for re-ordering the books on the reading list page.
-6. change the genre details page so that the book details in the list view match the style & format of the main book list page. Both pages. should use the same html fragment to ensure they stay the same. 
-7. Keep the design professional, but add in a bit more subtle color. 
+6. ✅ change the genre details page so that the book details in the list view match the style & format of the main book list page. Both pages should use the same html fragment to ensure they stay the same.
+7. Keep the design professional, but add in a bit more subtle color.
 


### PR DESCRIPTION
## Summary
- Render genre book lists with the shared `BookTable` component for consistent styling
- Allow `BookTable` to accept a `baseUrl` prop so sorting works on genre pages
- Provide genre-aware book data by returning `BookWithGenres` from `getBooksByGenre`

## Testing
- `npm test` *(fails: Could not load credentials from any providers)*

------
https://chatgpt.com/codex/tasks/task_e_68afc85c2b0c8333b17ecc436511d21d