### PR TITLE
Align genre details page width with book list

### DIFF
--- a/src/components/GenreView.tsx
+++ b/src/components/GenreView.tsx
@@ -63,7 +63,7 @@ export default function GenreView({ genreId }: GenreViewProps) {
 
   if (isLoading) {
     return (
-      <div className="max-w-4xl mx-auto p-6">
+      <div className="max-w-6xl mx-auto p-6">
         <div className="animate-pulse">
           <div className="h-8 bg-gray-200 rounded w-1/4 mb-6"></div>
           <div className="space-y-4">
@@ -77,7 +77,7 @@ export default function GenreView({ genreId }: GenreViewProps) {
 
   if (error && !genre) {
     return (
-      <div className="max-w-4xl mx-auto p-6">
+      <div className="max-w-6xl mx-auto p-6">
         <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
           {error}
         </div>
@@ -95,7 +95,7 @@ export default function GenreView({ genreId }: GenreViewProps) {
 
   if (!genre) {
     return (
-      <div className="max-w-4xl mx-auto p-6">
+      <div className="max-w-6xl mx-auto p-6">
         <div className="bg-yellow-50 border border-yellow-200 text-yellow-700 px-4 py-3 rounded">
           Genre not found
         </div>
@@ -112,7 +112,7 @@ export default function GenreView({ genreId }: GenreViewProps) {
   }
 
   return (
-    <div className="max-w-4xl mx-auto p-6">
+    <div className="max-w-6xl mx-auto p-6">
       <div className="flex items-center justify-between mb-8">
         <h1 className="text-3xl font-bold text-gray-900">
           Genre Details


### PR DESCRIPTION
## Summary
- expand GenreView container to `max-w-6xl` so genre details page matches books list width

## Testing
- `npm test` *(fails: CredentialsProviderError, assertions)*
- `npm run lint` *(fails: numerous @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afcbb0dce48333a69ce364bae9486d