### PR TITLE
refactor: share book search component across pages

### DIFF
--- a/src/components/BookSearch.tsx
+++ b/src/components/BookSearch.tsx
@@ -7,9 +7,15 @@ import { Genre } from '@/lib/database-factory';
 
 interface BookSearchProps {
   genres?: Genre[];
+  baseUrl?: string;
+  includeAdvancedFilters?: boolean;
 }
 
-export default function BookSearch({ genres = [] }: BookSearchProps) {
+export default function BookSearch({
+  genres = [],
+  baseUrl = '/books',
+  includeAdvancedFilters = true,
+}: BookSearchProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [searchTerm, setSearchTerm] = useState(searchParams.get('search') || '');
@@ -33,8 +39,8 @@ export default function BookSearch({ genres = [] }: BookSearchProps) {
     
     // Reset to first page when searching
     params.set('page', '1');
-    
-    router.push(`/books?${params.toString()}`);
+
+    router.push(`${baseUrl}?${params.toString()}`);
   };
 
   const handleClear = () => {
@@ -42,13 +48,15 @@ export default function BookSearch({ genres = [] }: BookSearchProps) {
     const params = new URLSearchParams(searchParams);
     params.delete('search');
     params.set('page', '1');
-    router.push(`/books?${params.toString()}`);
+    router.push(`${baseUrl}?${params.toString()}`);
   };
 
   // Check if any advanced filters are active
-  const hasAdvancedFilters = ['yearFrom', 'yearTo', 'language', 'publisher', 'pageCountFrom', 'pageCountTo', 'genreIds'].some(param => 
-    searchParams.get(param)
-  );
+  const hasAdvancedFilters =
+    includeAdvancedFilters &&
+    ['yearFrom', 'yearTo', 'language', 'publisher', 'pageCountFrom', 'pageCountTo', 'genreIds'].some(param =>
+      searchParams.get(param)
+    );
 
   return (
     <div className="mb-6 space-y-4">
@@ -80,24 +88,26 @@ export default function BookSearch({ genres = [] }: BookSearchProps) {
         </div>
         
         {/* Advanced Filters Toggle */}
-        <button
-          onClick={() => setShowAdvancedFilters(!showAdvancedFilters)}
-          className={`px-4 py-3 border rounded-md transition-colors flex items-center space-x-2 ${
-            hasAdvancedFilters || showAdvancedFilters
-              ? 'bg-blue-50 border-blue-300 text-blue-700'
-              : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-50'
-          }`}
-        >
-          <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
-          </svg>
-          <span>Filters</span>
-          {hasAdvancedFilters && (
-            <span className="bg-blue-600 text-white text-xs rounded-full px-2 py-0.5 ml-1">
-              Active
-            </span>
-          )}
-        </button>
+        {includeAdvancedFilters && (
+          <button
+            onClick={() => setShowAdvancedFilters(!showAdvancedFilters)}
+            className={`px-4 py-3 border rounded-md transition-colors flex items-center space-x-2 ${
+              hasAdvancedFilters || showAdvancedFilters
+                ? 'bg-blue-50 border-blue-300 text-blue-700'
+                : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-50'
+            }`}
+          >
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+            </svg>
+            <span>Filters</span>
+            {hasAdvancedFilters && (
+              <span className="bg-blue-600 text-white text-xs rounded-full px-2 py-0.5 ml-1">
+                Active
+              </span>
+            )}
+          </button>
+        )}
       </div>
 
       {/* Search status */}
@@ -108,14 +118,14 @@ export default function BookSearch({ genres = [] }: BookSearchProps) {
       )}
 
       {/* Advanced Filters Panel */}
-      {showAdvancedFilters && (
+      {includeAdvancedFilters && showAdvancedFilters && (
         <div className="mt-4">
-          <BookAdvancedFilters 
-            genres={genres} 
-            onClose={() => setShowAdvancedFilters(false)} 
+          <BookAdvancedFilters
+            genres={genres}
+            onClose={() => setShowAdvancedFilters(false)}
           />
         </div>
       )}
     </div>
   );
-} 
+}

--- a/src/components/ReadBooksList.tsx
+++ b/src/components/ReadBooksList.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import BookCoverImage from '@/components/BookCoverImage';
+import BookSearch from '@/components/BookSearch';
 import { getCurrentUser } from '@/lib/auth';
 import CombinedRecommendations from './CombinedRecommendations';
 
@@ -34,10 +35,6 @@ export default function ReadBooksList() {
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [totalBooks, setTotalBooks] = useState(0);
-  // Unsubmitted text in the input
-  const [searchTerm, setSearchTerm] = useState('');
-  // Applied search taken from URL (controls fetching)
-  const [appliedSearch, setAppliedSearch] = useState('');
   const [sortBy, setSortBy] = useState('title');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
 
@@ -48,13 +45,7 @@ export default function ReadBooksList() {
     setCurrentPage(page);
   }, [page]);
 
-  // Keep appliedSearch in sync with URL; also mirror input to reflect current query
-  useEffect(() => {
-    const q = searchParams.get('search') || '';
-    setAppliedSearch(q);
-    setSearchTerm(q);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]);
+  const search = searchParams.get('search') || '';
 
   const fetchReadBooks = useCallback(async () => {
     setLoading(true);
@@ -64,7 +55,7 @@ export default function ReadBooksList() {
         limit: limit.toString(),
         sortBy,
         sortOrder,
-        ...(appliedSearch && { search: appliedSearch })
+        ...(search && { search })
       });
 
       // Get current user to include user ID in request
@@ -96,32 +87,16 @@ export default function ReadBooksList() {
     } finally {
       setLoading(false);
     }
-  }, [currentPage, appliedSearch, sortBy, sortOrder, limit]);
+  }, [currentPage, search, sortBy, sortOrder, limit]);
 
   useEffect(() => {
     fetchReadBooks();
   }, [fetchReadBooks]);
 
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
-    setCurrentPage(1);
-    const params = new URLSearchParams();
-    if (searchTerm) params.set('search', searchTerm);
-    if (currentPage > 1) params.set('page', '1');
-    router.push(`/read?${params.toString()}`);
-  };
-
-  const handleSort = (field: string) => {
-    const newOrder = sortBy === field && sortOrder === 'asc' ? 'desc' : 'asc';
-    setSortBy(field);
-    setSortOrder(newOrder);
-    setCurrentPage(1);
-  };
-
   const handlePageChange = (newPage: number) => {
     setCurrentPage(newPage);
     const params = new URLSearchParams();
-    if (appliedSearch) params.set('search', appliedSearch);
+    if (search) params.set('search', search);
     if (newPage > 1) params.set('page', newPage.toString());
     router.push(`/read?${params.toString()}`);
   };
@@ -178,34 +153,16 @@ export default function ReadBooksList() {
           </p>
         </div>
 
-        {/* Search and Sort Controls */}
-        <div className="mb-6 flex flex-col sm:flex-row gap-4">
-          <form onSubmit={handleSearch} className="flex-1">
-            <div className="flex">
-              <input
-                type="text"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                placeholder="Search by title or author..."
-                className="flex-1 px-4 py-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-              <button
-                type="submit"
-                className="px-4 py-2 bg-gray-700 hover:bg-gray-800 text-white rounded-r-md transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-gray-500 shadow-sm hover:shadow-md font-medium"
-              >
-                Search
-              </button>
-            </div>
-          </form>
-        </div>
+        {/* Search */}
+        <BookSearch baseUrl="/read" includeAdvancedFilters={false} />
 
         {/* Books Table */}
         {books.length === 0 ? (
           <div className="bg-white shadow rounded-lg p-8 text-center">
             <p className="text-gray-500 text-lg">
-              {searchTerm ? 'No read books found matching your search.' : "You haven't marked any books as read yet."}
+              {search ? 'No read books found matching your search.' : "You haven't marked any books as read yet."}
             </p>
-            {!searchTerm && (
+            {!search && (
               <Link
                 href="/books"
                 className="mt-4 inline-block px-4 py-2 bg-gray-700 hover:bg-gray-800 text-white rounded-lg transition-all duration-200 shadow-sm hover:shadow-md font-medium"


### PR DESCRIPTION
## Summary
- make BookSearch configurable so it can be reused
- reuse BookSearch on the read page to remove duplicated search UI

## Testing
- `npm run lint` (fails: '@typescript-eslint/no-unused-vars', 'Unexpected any', etc.)
- `npm test` (fails: CredentialsProviderError: Could not load credentials from any providers)


------
https://chatgpt.com/codex/tasks/task_e_68affc060cac8333b7aaa4f1d0bfda09