### PR TITLE
feat(auth): Auth hardening: centralize parsing, add CSRF, remove admin fallback, derive user IDs from cookies

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { userOperations } from '@/lib/database-factory';
+import { v4 as uuidv4 } from 'uuid';
 
 export async function POST(request: NextRequest) {
   try {
@@ -33,10 +34,32 @@ export async function POST(request: NextRequest) {
       hasPassword: !!user.password
     });
 
-    return NextResponse.json({
+    // Set user-id cookie (HttpOnly) and csrf-token cookie (readable for double-submit)
+    const response = NextResponse.json({
       message: 'Login successful',
       user
     });
+
+    const isProd = process.env.NODE_ENV === 'production';
+    const oneWeek = 7 * 24 * 60 * 60; // seconds
+    const csrfToken = uuidv4();
+
+    response.cookies.set('user-id', String(user.id), {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: isProd,
+      path: '/',
+      maxAge: oneWeek
+    });
+    response.cookies.set('csrf-token', csrfToken, {
+      httpOnly: false,
+      sameSite: 'lax',
+      secure: isProd,
+      path: '/',
+      maxAge: oneWeek
+    });
+
+    return response;
   } catch (error) {
     console.error('Login error:', error);
     return NextResponse.json(

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -2,9 +2,24 @@ import { NextResponse } from 'next/server';
 
 export async function POST() {
   try {
-    return NextResponse.json({
-      message: 'Logout successful'
+    const response = NextResponse.json({ message: 'Logout successful' });
+    const isProd = process.env.NODE_ENV === 'production';
+    // Clear cookies by setting maxAge to 0
+    response.cookies.set('user-id', '', {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: isProd,
+      path: '/',
+      maxAge: 0
     });
+    response.cookies.set('csrf-token', '', {
+      httpOnly: false,
+      sameSite: 'lax',
+      secure: isProd,
+      path: '/',
+      maxAge: 0
+    });
+    return response;
   } catch (error) {
     console.error('Logout error:', error);
     return NextResponse.json(
@@ -12,4 +27,4 @@ export async function POST() {
       { status: 500 }
     );
   }
-} 
+}

--- a/src/app/api/auth/profile/route.ts
+++ b/src/app/api/auth/profile/route.ts
@@ -1,23 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { userOperations } from '@/lib/database-factory';
+import { getUserIdFromRequest, validateCsrf } from '@/lib/server-auth';
 
 export async function GET(request: NextRequest) {
   try {
-    // Get user ID from authorization header
-    const authHeader = request.headers.get('authorization');
-    
-    let userId: number | null = null;
-    
-    // Try to get user ID from authorization header first
-    if (authHeader && authHeader.startsWith('Bearer ')) {
-      const token = authHeader.substring(7);
-      try {
-        const decoded = JSON.parse(atob(token));
-        userId = decoded.userId;
-      } catch (error) {
-        console.error('Error parsing auth token:', error);
-      }
-    }
+    const userId = getUserIdFromRequest(request);
     
     // If no user ID found, return 401
     if (!userId) {
@@ -76,19 +63,15 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    // Get user ID from authorization header
-    const authHeader = request.headers.get('authorization');
-    let userId: string | null = null;
-    
-    if (authHeader && authHeader.startsWith('Bearer ')) {
-      const token = authHeader.substring(7);
-      try {
-        const decoded = JSON.parse(atob(token));
-        userId = decoded.userId;
-      } catch (error) {
-        console.error('Error parsing auth token:', error);
-      }
+    // CSRF protection: require x-csrf-token header matching csrf-token cookie
+    if (!validateCsrf(request)) {
+      return NextResponse.json(
+        { error: 'CSRF validation failed' },
+        { status: 403 }
+      );
     }
+
+    const userId = getUserIdFromRequest(request);
 
     if (!userId) {
       return NextResponse.json(

--- a/src/app/api/reading-lists/[id]/books/reorder/route.ts
+++ b/src/app/api/reading-lists/[id]/books/reorder/route.ts
@@ -1,23 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readingListOperations } from '@/lib/database-factory';
+import { getUserFromRequest, validateCsrf } from '@/lib/server-auth';
 
-// Simple auth check - in a real app you'd use proper JWT/session auth
-async function getCurrentUser(request: NextRequest) {
-  const authHeader = request.headers.get('authorization');
-
-  if (authHeader && authHeader.startsWith('Bearer ')) {
-    return { id: '1cf02876-41b7-4019-adb1-7d165b6770a3' }; // Actual admin user UUID
-  }
-
-  return null;
-}
+// Auth helpers are imported from server-auth
 
 export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const user = await getCurrentUser(request);
+    const user = getUserFromRequest(request);
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -39,6 +31,11 @@ export async function PUT(
 
     if (!Array.isArray(book_ids) || book_ids.length === 0) {
       return NextResponse.json({ error: 'Valid book_ids array is required' }, { status: 400 });
+    }
+
+    // CSRF protection for modifying list order
+    if (!validateCsrf(request)) {
+      return NextResponse.json({ error: 'CSRF validation failed' }, { status: 403 });
     }
 
     const success = await (readingListOperations as any).reorderBooks(readingListId, book_ids);

--- a/src/app/api/reading-lists/[id]/books/route.ts
+++ b/src/app/api/reading-lists/[id]/books/route.ts
@@ -1,23 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readingListOperations } from '@/lib/database-factory';
+import { getUserFromRequest, validateCsrf } from '@/lib/server-auth';
 
-// Simple auth check - in a real app you'd use proper JWT/session auth
-async function getCurrentUser(request: NextRequest) {
-  const authHeader = request.headers.get('authorization');
-  
-  if (authHeader && authHeader.startsWith('Bearer ')) {
-    return { id: '1cf02876-41b7-4019-adb1-7d165b6770a3' }; // Actual admin user UUID
-  }
-  
-  return null;
-}
+// Auth helpers are imported from server-auth
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const user = await getCurrentUser(request);
+    const user = getUserFromRequest(request);
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -39,6 +31,11 @@ export async function POST(
 
     if (!book_id) {
       return NextResponse.json({ error: 'Valid book ID is required' }, { status: 400 });
+    }
+
+    // CSRF protection for modifying list contents
+    if (!validateCsrf(request)) {
+      return NextResponse.json({ error: 'CSRF validation failed' }, { status: 403 });
     }
 
     const readingListBook = await readingListOperations.addBook({
@@ -64,7 +61,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const user = await getCurrentUser(request);
+    const user = getUserFromRequest(request);
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -86,6 +83,11 @@ export async function DELETE(
 
     if (!bookId) {
       return NextResponse.json({ error: 'Valid book ID is required' }, { status: 400 });
+    }
+
+    // CSRF protection for modifying list contents
+    if (!validateCsrf(request)) {
+      return NextResponse.json({ error: 'CSRF validation failed' }, { status: 403 });
     }
 
     const success = await (readingListOperations as any).removeBook(readingListId, bookId);

--- a/src/app/api/reading-lists/[id]/route.ts
+++ b/src/app/api/reading-lists/[id]/route.ts
@@ -1,16 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readingListOperations } from '@/lib/database-factory';
+import { getUserFromRequest, validateCsrf } from '@/lib/server-auth';
 
-// Simple auth check - in a real app you'd use proper JWT/session auth
-async function getCurrentUser(request: NextRequest) {
-  const authHeader = request.headers.get('authorization');
-  
-  if (authHeader && authHeader.startsWith('Bearer ')) {
-    return { id: '1cf02876-41b7-4019-adb1-7d165b6770a3' }; // Actual admin user UUID
-  }
-  
-  return null;
-}
+// Auth helpers are imported from server-auth
 
 export async function GET(
   request: NextRequest,
@@ -37,7 +29,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const user = await getCurrentUser(request);
+    const user = getUserFromRequest(request);
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -56,6 +48,11 @@ export async function PUT(
 
     const body = await request.json();
     const { name, description, is_public } = body;
+
+    // CSRF protection for updating a list
+    if (!validateCsrf(request)) {
+      return NextResponse.json({ error: 'CSRF validation failed' }, { status: 403 });
+    }
 
     const updatedReadingList = await readingListOperations.update(id, {
       name: name?.trim(),
@@ -79,7 +76,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const user = await getCurrentUser(request);
+    const user = getUserFromRequest(request);
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -94,6 +91,11 @@ export async function DELETE(
 
     if (readingList.user_id !== user.id) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    // CSRF protection for deleting a list
+    if (!validateCsrf(request)) {
+      return NextResponse.json({ error: 'CSRF validation failed' }, { status: 403 });
     }
 
     const success = await readingListOperations.delete(id);

--- a/src/app/api/reading-lists/route.ts
+++ b/src/app/api/reading-lists/route.ts
@@ -1,24 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readingListOperations } from '@/lib/database-factory';
+import { getUserFromRequest, validateCsrf } from '@/lib/server-auth';
 
-// Simple auth check - in a real app you'd use proper JWT/session auth
-async function getCurrentUser(request: NextRequest) {
-  // For now, we'll use a simple approach
-  // In a real app, you'd decode JWT tokens or check session cookies
-  const authHeader = request.headers.get('authorization');
-  
-  if (authHeader && authHeader.startsWith('Bearer ')) {
-    // This is a placeholder - in a real app you'd decode a JWT token
-    // For now, we'll return the actual admin user UUID
-    return { id: '1cf02876-41b7-4019-adb1-7d165b6770a3' }; // Actual admin user UUID
-  }
-  
-  return null;
-}
+// Auth helpers are imported from server-auth
 
 export async function GET(request: NextRequest) {
   try {
-    const user = await getCurrentUser(request);
+    const user = getUserFromRequest(request);
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -42,9 +30,14 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getCurrentUser(request);
+    const user = getUserFromRequest(request);
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // CSRF protection for creating a list
+    if (!validateCsrf(request)) {
+      return NextResponse.json({ error: 'CSRF validation failed' }, { status: 403 });
     }
 
     const body = await request.json();

--- a/src/app/api/recommendations/route.ts
+++ b/src/app/api/recommendations/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { userBookAssociationOperations, bookOperations } from '@/lib/database-factory';
+import { getUserIdFromRequest } from '@/lib/server-auth';
 
 interface BookRecommendation {
   title: string;
@@ -10,45 +11,11 @@ interface BookRecommendation {
 
 export async function GET(request: NextRequest) {
   try {
-    // Get user ID from request using the same pattern as other API routes
-    const cookieHeader = request.headers.get('cookie');
-    let userId: string | null = null;
+    const userId = getUserIdFromRequest(request);
     
-    if (cookieHeader) {
-      const cookies = cookieHeader.split(';').reduce((acc, cookie) => {
-        const [key, value] = cookie.trim().split('=');
-        acc[key] = value;
-        return acc;
-      }, {} as Record<string, string>);
-      
-      // Try to get user ID from a custom cookie
-      if (cookies['user-id']) {
-        userId = cookies['user-id'];
-      }
-    }
-    
-    // Fallback: try to get from Authorization header
+    // If still no user, reject
     if (!userId) {
-      const authHeader = request.headers.get('authorization');
-      if (authHeader && authHeader.startsWith('Bearer ')) {
-        const token = authHeader.substring(7);
-        // In a real app, you'd decode the JWT token here
-        // For now, we'll use a simple approach
-        try {
-          const decoded = JSON.parse(Buffer.from(token, 'base64').toString());
-          userId = decoded.userId;
-        } catch {
-          // Invalid token
-        }
-      }
-    }
-    
-    // For now, if we can't get the user ID, we'll use a default
-    // This should be replaced with proper authentication
-    if (!userId) {
-      // Return an error in production, but for demo purposes, use admin user ID
-      console.warn('No user ID found in request, using default user ID 1cf02876-41b7-4019-adb1-7d165b6770a3');
-      userId = '1cf02876-41b7-4019-adb1-7d165b6770a3';
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     console.log('Recommendations API - Using userId:', userId);

--- a/src/app/api/user-books/[bookId]/route.ts
+++ b/src/app/api/user-books/[bookId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { userBookAssociationOperations } from '@/lib/database-factory';
+import { validateCsrf, getUserIdFromRequest } from '@/lib/server-auth';
 
 // GET /api/user-books/[bookId] - Get user's association for a specific book
 export async function GET(
@@ -7,22 +8,9 @@ export async function GET(
   { params }: { params: Promise<{ bookId: string }> }
 ) {
   try {
-    const { searchParams } = new URL(request.url);
-    const userId = searchParams.get('userId');
-    
-    if (!userId) {
-      return NextResponse.json(
-        { error: 'User ID is required' },
-        { status: 400 }
-      );
-    }
-
-    // Validate userId is a non-empty string
-    if (userId.trim() === '') {
-      return NextResponse.json(
-        { error: 'Invalid user ID' },
-        { status: 400 }
-      );
+    const userId = getUserIdFromRequest(request);
+    if (!userId || userId.trim() === '') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const resolvedParams = await params;
@@ -61,21 +49,12 @@ export async function PUT(
 ) {
   try {
     const body = await request.json();
-    const { user_id, read_status, rating, comments } = body;
+    const { read_status, rating, comments } = body;
+    // Derive user ID from cookie/authorization instead of trusting body
+    const user_id = getUserIdFromRequest(request);
 
-    if (!user_id) {
-      return NextResponse.json(
-        { error: 'User ID is required' },
-        { status: 400 }
-      );
-    }
-
-    // Validate user_id is a non-empty string
-    if (user_id.trim() === '') {
-      return NextResponse.json(
-        { error: 'Invalid user ID' },
-        { status: 400 }
-      );
+    if (!user_id || user_id.trim() === '') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const resolvedParams = await params;
@@ -111,6 +90,14 @@ export async function PUT(
       comments
     };
 
+    // CSRF protection for updates
+    if (!validateCsrf(request)) {
+      return NextResponse.json(
+        { error: 'CSRF validation failed' },
+        { status: 403 }
+      );
+    }
+
     const association = await userBookAssociationOperations.update(user_id, bookId, updateData);
     if (!association) {
       return NextResponse.json(
@@ -135,22 +122,10 @@ export async function DELETE(
   { params }: { params: Promise<{ bookId: string }> }
 ) {
   try {
-    const { searchParams } = new URL(request.url);
-    const userId = searchParams.get('userId');
-    
-    if (!userId) {
-      return NextResponse.json(
-        { error: 'User ID is required' },
-        { status: 400 }
-      );
-    }
-
-    // Validate userId is a non-empty string
-    if (userId.trim() === '') {
-      return NextResponse.json(
-        { error: 'Invalid user ID' },
-        { status: 400 }
-      );
+    // Derive user ID from cookie/authorization instead of trusting query
+    const userId = getUserIdFromRequest(request);
+    if (!userId || userId.trim() === '') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const resolvedParams = await params;
@@ -161,6 +136,14 @@ export async function DELETE(
       return NextResponse.json(
         { error: 'Invalid book ID' },
         { status: 400 }
+      );
+    }
+
+    // CSRF protection for deletions
+    if (!validateCsrf(request)) {
+      return NextResponse.json(
+        { error: 'CSRF validation failed' },
+        { status: 403 }
       );
     }
 

--- a/src/app/api/user-books/read/route.ts
+++ b/src/app/api/user-books/read/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { userBookAssociationOperations } from '@/lib/database-factory';
+import { getUserIdFromRequest } from '@/lib/server-auth';
 
 export async function GET(request: NextRequest) {
   try {
@@ -10,48 +11,13 @@ export async function GET(request: NextRequest) {
     const sortOrder = (searchParams.get('sortOrder') || 'asc') as 'asc' | 'desc';
     const search = searchParams.get('search') || '';
 
-    // In a real app, you'd use proper session management or JWT tokens
-    const cookieHeader = request.headers.get('cookie');
-    let userId: string | number | null = null;
-    
-    if (cookieHeader) {
-      const cookies = cookieHeader.split(';').reduce((acc, cookie) => {
-        const [key, value] = cookie.trim().split('=');
-        acc[key] = value;
-        return acc;
-      }, {} as Record<string, string>);
-      
-      // Try to get user ID from a custom cookie
-      if (cookies['user-id']) {
-        userId = parseInt(cookies['user-id']);
-      }
-    }
-    
-    // Fallback: try to get from Authorization header
+    const userId = getUserIdFromRequest(request);
+
     if (!userId) {
-      const authHeader = request.headers.get('authorization');
-      if (authHeader && authHeader.startsWith('Bearer ')) {
-        const token = authHeader.substring(7);
-        // In a real app, you'd decode the JWT token here
-        // For now, we'll use a simple approach
-        try {
-          const decoded = JSON.parse(Buffer.from(token, 'base64').toString());
-          userId = decoded.userId;
-        } catch {
-          // Invalid token
-        }
-      }
-    }
-    
-    // For now, if we can't get the user ID, we'll use a default
-    // This should be replaced with proper authentication
-    if (!userId) {
-      // Return an error in production, but for demo purposes, use admin user ID
-      console.warn('No user ID found in request, using default user ID 1cf02876-41b7-4019-adb1-7d165b6770a3');
-      userId = '1cf02876-41b7-4019-adb1-7d165b6770a3';
-    } else {
-      // Convert number to string for DynamoDB
-      userId = userId.toString();
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      );
     }
 
     const result = await userBookAssociationOperations.getReadBooksWithPagination(

--- a/src/app/api/user-books/route.ts
+++ b/src/app/api/user-books/route.ts
@@ -1,27 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { userBookAssociationOperations, userOperations, bookOperations } from '@/lib/database-factory';
+import { validateCsrf, getUserIdFromRequest } from '@/lib/server-auth';
 
 // GET /api/user-books - Get user's book associations
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
-    const userId = searchParams.get('userId');
     const page = searchParams.get('page') ? parseInt(searchParams.get('page')!) : 1;
     const limit = searchParams.get('limit') ? parseInt(searchParams.get('limit')!) : 10;
-    
-    if (!userId) {
-      return NextResponse.json(
-        { error: 'User ID is required' },
-        { status: 400 }
-      );
-    }
 
-    // Validate userId is a non-empty string
-    if (userId.trim() === '') {
-      return NextResponse.json(
-        { error: 'Invalid user ID' },
-        { status: 400 }
-      );
+    const userId = getUserIdFromRequest(request);
+    if (!userId || userId.trim() === '') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     // Debug: Check if user exists
@@ -56,11 +46,13 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { user_id, book_id, read_status, rating, comments } = body;
+    const { book_id, read_status, rating, comments } = body;
 
     console.log('Creating user-book association - Raw body:', body);
-    console.log('Creating user-book association - user_id type:', typeof user_id, 'value:', user_id);
     console.log('Creating user-book association - book_id type:', typeof book_id, 'value:', book_id);
+
+    // Derive user ID from cookie/authorization instead of trusting body
+    const user_id = getUserIdFromRequest(request);
 
     if (!user_id || !book_id) {
       return NextResponse.json(
@@ -71,7 +63,7 @@ export async function POST(request: NextRequest) {
 
     // Validate user_id and book_id are strings
     if (typeof user_id !== 'string' || user_id.trim() === '') {
-      console.error('Validation failed - user_id is not a valid string:', typeof user_id, user_id);
+      console.error('Validation failed - derived user_id is not a valid string:', typeof user_id, user_id);
       return NextResponse.json(
         { error: 'User ID must be a valid string' },
         { status: 400 }
@@ -131,6 +123,14 @@ export async function POST(request: NextRequest) {
     };
 
     console.log('Creating association with data:', associationData);
+
+    // CSRF protection for creating/updating associations
+    if (!validateCsrf(request)) {
+      return NextResponse.json(
+        { error: 'CSRF validation failed' },
+        { status: 403 }
+      );
+    }
 
     const association = await userBookAssociationOperations.upsert(associationData);
     return NextResponse.json(association, { status: 201 });

--- a/src/lib/server-auth.ts
+++ b/src/lib/server-auth.ts
@@ -1,19 +1,39 @@
 import { NextRequest } from 'next/server';
 import { userOperations } from './database-factory';
 
-// Server-side function to get user ID from request
+// Get user ID from cookie `user-id` or Authorization header (Bearer <base64>{"userId":...})
 export function getUserIdFromRequest(request: NextRequest): string | null {
-  // For now, we'll use a simple approach with headers
-  // In a real app, you'd use JWT tokens or session cookies
-  const authHeader = request.headers.get('authorization');
-  
-  if (authHeader && authHeader.startsWith('Bearer ')) {
-    // This is a placeholder - in a real app you'd decode a JWT token
-    // For now, we'll return null and let the client handle auth
-    return null;
+  // Try cookie first
+  const cookieHeader = request.headers.get('cookie');
+  if (cookieHeader) {
+    const cookies = cookieHeader.split(';').reduce((acc, cookie) => {
+      const [key, value] = cookie.trim().split('=');
+      acc[key] = value;
+      return acc;
+    }, {} as Record<string, string>);
+    if (cookies['user-id']) return cookies['user-id'];
   }
-  
+
+  // Fallback to Authorization header
+  const authHeader = request.headers.get('authorization');
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.substring(7);
+    try {
+      const decoded = JSON.parse(Buffer.from(token, 'base64').toString());
+      if (decoded?.userId !== undefined && decoded?.userId !== null) {
+        return String(decoded.userId);
+      }
+    } catch {
+      // ignore invalid token
+    }
+  }
+
   return null;
+}
+
+export function getUserFromRequest(request: NextRequest): { id: string } | null {
+  const id = getUserIdFromRequest(request);
+  return id ? { id } : null;
 }
 
 // Server-side function to validate user exists
@@ -27,4 +47,18 @@ export function validateUser(userId: string): boolean {
     console.error('Error validating user:', error);
     return false;
   }
-} 
+}
+
+// CSRF validation using double-submit cookie: header `x-csrf-token` must match `csrf-token` cookie
+export function validateCsrf(request: NextRequest): boolean {
+  const headerToken = request.headers.get('x-csrf-token');
+  if (!headerToken) return false;
+  const cookieHeader = request.headers.get('cookie');
+  if (!cookieHeader) return false;
+  const cookies = cookieHeader.split(';').reduce((acc, cookie) => {
+    const [key, value] = cookie.trim().split('=');
+    acc[key] = value;
+    return acc;
+  }, {} as Record<string, string>);
+  return cookies['csrf-token'] === headerToken;
+}


### PR DESCRIPTION
Summary
Centralizes server auth parsing (cookie or Bearer base64 JSON).
Adds CSRF protection for state-changing routes (double-submit cookie).
Removes hardcoded “admin” fallback; unauthenticated calls return 401.
Derives user IDs from cookies/authorization on user-books reads/writes.
Replaces atob with Buffer decoding on server.

Motivation: 
Avoid unsafe defaults (admin fallback).
Eliminate duplicate, inconsistent auth parsing.
Protect write endpoints from CSRF.
Ensure user identity is trusted (not supplied in body/query).

Key Changes:
Shared helpers
src/lib/server-auth.ts
getUserIdFromRequest: Reads user-id cookie, else Bearer base64 JSON {"userId": ...}.
getUserFromRequest: Convenience wrapper returning { id } | null.
validateCsrf: Double-submit check of x-csrf-token header vs csrf-token cookie.
Auth routes
src/app/api/auth/login/route.ts
Sets user-id (HttpOnly) and csrf-token cookies on success.
src/app/api/auth/logout/route.ts
Clears both cookies.
src/app/api/auth/profile/route.ts
Uses shared helpers; 401 when unauthenticated; CSRF on PUT; Buffer decoding.
Reading lists
src/app/api/reading-lists/route.ts
src/app/api/reading-lists/[id]/route.ts
src/app/api/reading-lists/[id]/books/route.ts
src/app/api/reading-lists/[id]/books/reorder/route.ts
Use shared helpers; 401 if unauthenticated; CSRF on POST/PUT/DELETE.
Recommendations
src/app/api/recommendations/route.ts
Uses shared helper; 401 if unauthenticated; no admin fallback.
User-books
src/app/api/user-books/route.ts
GET derives userId from request; 401 if missing.
POST derives userId from request; CSRF enforced.
src/app/api/user-books/[bookId]/route.ts
GET/PUT/DELETE derive userId from request; CSRF on PUT/DELETE.
src/app/api/user-books/read/route.ts
Uses shared helper; 401 if unauthenticated.

Behavioral Changes:
No more defaulting to admin user when no auth is present.
All writes require header x-csrf-token: <csrf-token cookie>.
User-books routes do not accept user_id in body or userId in query; derive from cookie/Authorization.

